### PR TITLE
Bundle PIL._tkinter_finder so the Linux build doesn't crash on startup (fixes #5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           pyinstaller --onefile --windowed --name "SCPlaytime" `
             --add-data "resources;resources" `
+            --hidden-import "PIL._tkinter_finder" `
             sc_main.py
 
       - name: Upload Python Windows artifact
@@ -103,6 +104,7 @@ jobs:
         run: |
           pyinstaller --onefile --windowed --name "SCPlaytime" \
             --add-data "resources:resources" \
+            --hidden-import "PIL._tkinter_finder" \
             sc_main.py
 
       - name: Upload Python Linux artifact

--- a/python/build_exe.bat
+++ b/python/build_exe.bat
@@ -72,6 +72,7 @@ pyinstaller ^
     --windowed ^
     --name "SCPlaytime" ^
     --add-data "resources;resources" ^
+    --hidden-import "PIL._tkinter_finder" ^
     --clean ^
     --noconfirm ^
     sc_main.py


### PR DESCRIPTION
## Problem

The packaged **Linux** artifact (v4.1) crashes immediately on launch:

```
ModuleNotFoundError: No module named 'PIL._tkinter_finder'
```

(preceded by `_tkinter.TclError: invalid command name "PyImagingPhoto"`). Running from source works fine, because nothing is frozen there.

## Root cause

`PIL.ImageTk` imports `PIL._tkinter_finder` **at runtime** to register Pillow's image objects with the Tcl/Tk interpreter (the `PyImagingPhoto` command). The first `ImageTk` call happens at startup when ttkbootstrap draws the combobox arrow asset — so a missing `_tkinter_finder` is fatal.

PyInstaller only auto-collects that submodule on some versions of `pyinstaller` / `pyinstaller-hooks-contrib`. Our CI uses **unpinned** `pip install pyinstaller`, so the version present when v4.1 was tagged didn't include it.

## Fix

Add `--hidden-import "PIL._tkinter_finder"` to all three build paths (CI Linux, CI Windows, `build_exe.bat`) so it is **always** bundled, independent of the PyInstaller version.

## Verification

- **Linux (WSL Ubuntu 24.04)** and **Windows**, fresh PyInstaller 6.21.0 / Pillow 12.2.0: built the frozen probe both ways. The flag reliably includes the module and the ttkbootstrap `Combobox` -> `ImageTk` path succeeds. The flag is a **no-op where the module is already collected**, so there is no risk to platforms that were already working.

## Recommended follow-up (not in this PR)

This bug was caused by build-tool version drift. Consider **pinning** `pyinstaller` (e.g. `pyinstaller==6.21.0`) in CI so releases are reproducible and packaging cannot silently regress again.