### PR TITLE
Pin build & runtime deps for reproducible, CVE-clean releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pyinstaller
+          pip install pyinstaller==6.21.0
 
       - name: Build executable
         working-directory: python
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pyinstaller
+          pip install pyinstaller==6.21.0
 
       - name: Build executable
         working-directory: python

--- a/python/build_exe.bat
+++ b/python/build_exe.bat
@@ -50,7 +50,7 @@ if errorlevel 1 (
 
 :: Install PyInstaller if needed
 echo [INFO] Checking PyInstaller...
-pip install pyinstaller --quiet
+pip install pyinstaller==6.21.0 --quiet
 if errorlevel 1 (
     echo [ERROR] Failed to install PyInstaller
     goto :error

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,6 @@
-python-dateutil>=2.8.0
-pillow>=9.0.0
-ttkbootstrap>=1.10.0
+# Pinned for reproducible, CVE-clean release builds.
+# pillow<12.2.0 carries known CVEs (incl. ImageMath.eval RCE CVE-2023-50447,
+# libwebp heap overflow CVE-2023-4863); see CVE audit before bumping.
+python-dateutil==2.9.0.post0
+pillow==12.2.0
+ttkbootstrap==1.20.3


### PR DESCRIPTION
## Why

Issue #5 shipped a broken Linux build purely because of **version drift**: CI ran unpinned `pip install pyinstaller`, and the version it happened to grab at release time did not bundle `PIL._tkinter_finder`. Pinning the toolchain makes that class of "worked yesterday, broken today" failure impossible.

## CVE audit (pip-audit, OSV / PyPI advisory DB)

- **Current resolved versions: clean** (0 vulnerabilities across all 11 packages).
- **`requirements.txt` floors were not**: `pillow>=9.0.0` allows **12 known CVEs**, including:
  - `CVE-2023-50447` / `CVE-2022-22817` — `ImageMath.eval` arbitrary code execution
  - `CVE-2023-4863` — libwebp heap buffer overflow
  - `CVE-2024-28219` — buffer overflow in `_imagingcms`
  - plus several DoS issues; all fixed by **12.2.0**.
  - `python-dateutil` and `ttkbootstrap` floors were clean (pinned for reproducibility only).

## Changes

- `pyinstaller==6.21.0` — CI build jobs + `build_exe.bat` (the #5 root-cause guard).
- `pillow==12.2.0` — clears all 12 CVEs above.
- `python-dateutil==2.9.0.post0`, `ttkbootstrap==1.20.3`.

These are the exact versions that built the **verified-working v4.2** artifacts, so the build output is unchanged — this only locks it.

## Follow-up suggestion

Enable Dependabot (pip + github-actions) so these pins get automated update PRs instead of silently aging.