### PR TITLE
Detect Star Citizen installs on any drive and custom library folders (C#)

### DIFF
--- a/csharp/Form1.cs
+++ b/csharp/Form1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -49,25 +50,34 @@ namespace StarCitizenPlaytimeCalculator
             detectedPaths.Clear();
             comboEnvironment.Items.Clear();
 
-            // Common installation paths to check
-            string[] drivesToCheck = { "C", "D", "E", "F", "G" };
             string[] environments = { "LIVE", "PTU", "EPTU", "TECH-PREVIEW" };
 
-            foreach (var drive in drivesToCheck)
+            var seenBases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var rawBase in GetCandidateBasePaths())
             {
-                string basePath = $@"{drive}:\Program Files\Roberts Space Industries\StarCitizen";
+                string basePath;
+                try { basePath = Path.GetFullPath(rawBase); }
+                catch { continue; }
 
-                if (Directory.Exists(basePath))
+                if (!seenBases.Add(basePath) || !Directory.Exists(basePath))
+                    continue;
+
+                string driveLetter = basePath.Length > 0
+                    ? char.ToUpperInvariant(basePath[0]).ToString()
+                    : "";
+
+                foreach (var env in environments)
                 {
-                    foreach (var env in environments)
-                    {
-                        string logPath = Path.Combine(basePath, env, "logbackups");
-                        if (Directory.Exists(logPath))
-                        {
-                            string key = drive == "C" ? env : $"{env} ({drive}:)";
-                            detectedPaths[key] = logPath;
-                        }
-                    }
+                    string logPath = Path.Combine(basePath, env, "logbackups");
+                    if (!Directory.Exists(logPath))
+                        continue;
+
+                    string key = driveLetter == "C" ? env : $"{env} ({driveLetter}:)";
+                    // If two installs collide on the same key, disambiguate by full path.
+                    if (detectedPaths.TryGetValue(key, out var existing) && existing != logPath)
+                        key = $"{env} ({basePath})";
+                    if (!detectedPaths.ContainsKey(key))
+                        detectedPaths[key] = logPath;
                 }
             }
 
@@ -92,6 +102,68 @@ namespace StarCitizenPlaytimeCalculator
                 }
                 UpdateStatus("No Star Citizen installation detected - please browse manually", StatusType.Warning);
             }
+        }
+
+        // Candidate Star Citizen base install directories: common roots on every
+        // fixed drive, plus any custom library folder recorded by the RSI Launcher.
+        private static List<string> GetCandidateBasePaths()
+        {
+            var bases = new List<string>();
+            string[] commonRoots =
+            {
+                @"Program Files\Roberts Space Industries\StarCitizen",
+                @"Roberts Space Industries\StarCitizen",
+                @"Games\Roberts Space Industries\StarCitizen",
+                @"Games\StarCitizen",
+                @"StarCitizen",
+            };
+
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                if (!drive.IsReady || drive.DriveType != DriveType.Fixed)
+                    continue;
+                foreach (var root in commonRoots)
+                    bases.Add(Path.Combine(drive.RootDirectory.FullName, root));
+            }
+
+            // User AppData.
+            bases.Add(Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                @"Roberts Space Industries\StarCitizen"));
+
+            // Authoritative source for custom library folders.
+            bases.AddRange(PathsFromLauncherLog());
+            return bases;
+        }
+
+        // Star Citizen base dirs recorded by the RSI Launcher log. The launcher's
+        // settings store is encrypted, but it logs plaintext lines such as
+        // "Installing Star Citizen LIVE ... at G:\Games\StarCitizen" - the only
+        // reliable way to find an install in a custom library folder.
+        private static List<string> PathsFromLauncherLog()
+        {
+            var bases = new List<string>();
+            string logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                @"rsilauncher\logs\log.log");
+            if (!File.Exists(logPath))
+                return bases;
+
+            string content;
+            try { content = File.ReadAllText(logPath); }
+            catch { return bases; }
+
+            // Backslashes are JSON-escaped (doubled) in the log; the match is
+            // non-greedy so it stops at the shallowest StarCitizen directory.
+            var rx = new Regex(@"[A-Za-z]:(?:\\\\[^\\""(),]+)*?\\\\StarCitizen(?![A-Za-z0-9])");
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (Match m in rx.Matches(content))
+            {
+                string p = m.Value.Replace(@"\\", @"\");
+                if (seen.Add(p))
+                    bases.Add(p);
+            }
+            return bases;
         }
 
         private void comboEnvironment_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary

Ports the install-detection improvements (PR #7) to the **C# / WinForms** app for parity.

`DetectInstallations()` previously checked only `<drive>:\Program Files\Roberts Space Industries\StarCitizen` across drives C-G. So even though it scanned G, a custom library folder like **`G:\Games\StarCitizen`** was never found and the app fell back to "No installations found".

## Changes (`Form1.cs`)

- **Scan every fixed drive** via `DriveInfo.GetDrives()` instead of a hardcoded `C-G` list.
- **Cover common custom roots**: `Games\Roberts Space Industries\StarCitizen`, `Games\StarCitizen`, bare `StarCitizen`, plus the original two.
- **Read the authoritative path from the RSI Launcher log** (`%APPDATA%\rsilauncher\logs\log.log`) — the only reliable source for a fully custom library folder.
- All candidates are still **verified against `<env>\logbackups` on disk**, so stale/moved installs are dropped.

## Verification

- Built locally with the **exact CI flags** (`/p:TreatWarningsAsErrors=true /p:RunAnalyzersDuringBuild=true`) — **builds clean, no warnings**.
- Validated the ported regex against a real launcher log via the .NET engine: it extracts `G:\Games\StarCitizen` (and a stale `C:\…` entry that is correctly discarded because its `logbackups` no longer exists), yielding `LIVE (G:)` — matching the Python implementation.